### PR TITLE
Util + Processor parts

### DIFF
--- a/PETsARD/Error.py
+++ b/PETsARD/Error.py
@@ -1,2 +1,17 @@
+"""
+...
+TODO:
+    LoadingError in Loader_excel_pandas.py
+    ResultError  in Anonymeter.py -> or make it as Reporter
+    MethodError  in SynthesizerFactory.py
+                    Anonymeter.py
+                    SDVFactory.py
+                    SDV_SingleTableFactory.py
+    UnfittedError in SDV_SingleTable.py
+    SamplingError in Splitter.py
+    UnsupportDtypeError in df_cast_check.py
+"""
+
+
 class UnfittedError(Exception):
     pass

--- a/PETsARD/Processor/Base.py
+++ b/PETsARD/Processor/Base.py
@@ -1,4 +1,7 @@
+from copy import deepcopy
+import logging
 import warnings
+
 from .Encoder import *
 from .Missingist import *
 from .Outlierist import *
@@ -7,8 +10,6 @@ from .Mediator import *
 from ..Error import *
 from ..Metadata import Metadata
 
-from copy import deepcopy
-import logging
 
 logging.basicConfig(level=logging.INFO, filename='log.txt', filemode='w',
                     format='[%(levelname).1s %(asctime)s] %(message)s',

--- a/PETsARD/Processor/Encoder.py
+++ b/PETsARD/Processor/Encoder.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
-from ..Error import UnfittedError
 from sklearn.preprocessing import LabelEncoder
+
+from ..Error import UnfittedError
 
 
 class Encoder:
@@ -14,6 +15,7 @@ class Encoder:
     Return:
         None
     """
+
     def __init__(self) -> None:
         # Mapping dict
         self.cat_to_val: dict = None
@@ -118,6 +120,7 @@ class Encoder_Uniform(Encoder):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -203,6 +206,7 @@ class Encoder_Label(Encoder):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.model: LabelEncoder = LabelEncoder()

--- a/PETsARD/Processor/Mediator.py
+++ b/PETsARD/Processor/Mediator.py
@@ -1,8 +1,8 @@
-from .Missingist import Missingist_Drop
-from .Outlierist import *
-
 from sklearn.ensemble import IsolationForest
 from sklearn.neighbors import LocalOutlierFactor
+
+from .Missingist import Missingist_Drop
+from .Outlierist import *
 
 
 class Mediator:
@@ -69,6 +69,7 @@ class Mediator_Missingist(Mediator):
     Return:
         None
     """
+
     def __init__(self, config: dict) -> None:
         super().__init__()
         self._config: dict = config['missingist']
@@ -102,7 +103,8 @@ class Mediator_Missingist(Mediator):
             col_name: str = self._process_col[0]
             process_filter: np.ndarray = data[col_name].values
 
-            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(drop=True)
+            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(
+                drop=True)
 
             # restore the original data from the boolean data
             transformed.loc[:, col_name] = self._config.get(col_name,
@@ -110,9 +112,11 @@ class Mediator_Missingist(Mediator):
 
             return transformed
         else:
-            process_filter: np.ndarray = data[self._process_col].any(axis=1).values
+            process_filter: np.ndarray = data[self._process_col].any(
+                axis=1).values
 
-            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(drop=True)
+            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(
+                drop=True)
 
             for col in self._process_col:
                 # restore the original data from the boolean data
@@ -132,6 +136,7 @@ class Mediator_Outlierist(Mediator):
     Return:
         None
     """
+
     def __init__(self, config: dict) -> None:
         super().__init__()
         self._config: dict = config['outlierist']
@@ -191,18 +196,21 @@ class Mediator_Outlierist(Mediator):
         if self._global_model_indicator:
             # the model may classify most data as outliers after transformation by other processors
             # so fit_predict will be used in _transform
-            predict_result: np.ndarray = self.model.fit_predict(data[self._process_col])
+            predict_result: np.ndarray = self.model.fit_predict(
+                data[self._process_col])
             self.result: np.ndarray = predict_result
             process_filter: np.ndarray = predict_result == -1.0
 
-            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(drop=True)
+            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(
+                drop=True)
 
             return transformed
         elif len(self._process_col) == 1:
             col_name: str = self._process_col[0]
             process_filter: np.ndarray = data[col_name].values
 
-            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(drop=True)
+            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(
+                drop=True)
 
             # restore the original data from the boolean data
             transformed.loc[:, col_name] = self._config.get(col_name,
@@ -210,9 +218,11 @@ class Mediator_Outlierist(Mediator):
 
             return transformed
         else:
-            process_filter: np.ndarray = data[self._process_col].any(axis=1).values
+            process_filter: np.ndarray = data[self._process_col].any(
+                axis=1).values
 
-            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(drop=True)
+            transformed: pd.DataFrame = data.loc[~process_filter, :].reset_index(
+                drop=True)
 
             for col in self._process_col:
                 # restore the original data from the boolean data

--- a/PETsARD/Processor/Missingist.py
+++ b/PETsARD/Processor/Missingist.py
@@ -1,8 +1,9 @@
+from copy import deepcopy
+
 import numpy as np
 import pandas as pd
-from ..Error import UnfittedError
 
-from copy import deepcopy
+from ..Error import UnfittedError
 
 
 class Missingist:

--- a/PETsARD/Processor/Outlierist.py
+++ b/PETsARD/Processor/Outlierist.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
-from ..Error import UnfittedError
 from sklearn.preprocessing import StandardScaler
+
+from ..Error import UnfittedError
 
 
 class Outlierist:
@@ -14,6 +15,7 @@ class Outlierist:
     Return:
         None
     """
+
     def __init__(self) -> None:
         self._is_fitted: bool = False
         self.data_backup: np.ndarray = None  # for restoring data

--- a/PETsARD/Processor/Scaler.py
+++ b/PETsARD/Processor/Scaler.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
-from ..Error import UnfittedError
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import MinMaxScaler
+
+from ..Error import UnfittedError
 
 
 class Scaler:
@@ -15,6 +16,7 @@ class Scaler:
     Return:
         None
     """
+
     def __init__(self) -> None:
         self._is_fitted: bool = False
 
@@ -104,6 +106,7 @@ class Scaler_Standard(Scaler):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.model: StandardScaler = StandardScaler()
@@ -157,6 +160,7 @@ class Scaler_ZeroCenter(Scaler_Standard):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.model: StandardScaler = StandardScaler(with_std=False)
@@ -172,6 +176,7 @@ class Scaler_MinMax(Scaler_Standard):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.model: MinMaxScaler = MinMaxScaler()
@@ -187,6 +192,7 @@ class Scaler_Log(Scaler):
     Return:
         None
     """
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/PETsARD/util/__init__.py
+++ b/PETsARD/util/__init__.py
@@ -1,7 +1,8 @@
 from .df_cast_check import df_cast_check
-from .df_casting    import df_casting
+from .df_casting import df_casting
 
 
-__all__ = ['df_cast_check'
-          ,'df_casting'
-          ]
+__all__ = [
+    'df_cast_check',
+    'df_casting'
+]

--- a/PETsARD/util/df_cast_check.py
+++ b/PETsARD/util/df_cast_check.py
@@ -1,123 +1,144 @@
+from dateutil.parser import parse
+import numpy as np
+import pandas as pd
+from pandas.api.types import (
+    is_string_dtype,
+    is_numeric_dtype,
+    is_integer_dtype,
+    is_float_dtype
+)
 
-def df_cast_check(df_data    # : pd.DataFrame
-                 ,dict_dtype   : dict         = None
-                 ) -> dict:
+
+def df_cast_check(
+    df_data:    pd.DataFrame,
+    dict_dtype: dict = None
+) -> dict:
     """
-    Function for Check each column best dtypes with its mininum stroage of pd.DataFrame
+    Function for Check each column best dtypes
+        with its mininum stroage of pd.DataFrame
 
     - For Data of 'Object' Type:
-        - Categorize as 'categorical' if the majority of the data cannot be recognized as a date, specifically when the count of non-date entries is greater than or equal to the maximum count of either date or datetime entries.
-        - Otherwise, categorize as 'datetime' if any time information is included
+        - Categorize as 'categorical'
+            if the majority of the data cannot be recognized as a date,
+            specifically when the count of non-date entries
+            is greater than or equal to
+            the maximum count of either date or datetime entries.
+        - Otherwise, categorize as 'datetime'
+            if any time information is included
         - In all other cases, categorize as 'date'.
-    
-    20231103, Justyn:
-        pandas didn't suppot float16 engine,
-        and some of library will try to handle your column as index (e.g. SDV, Gaussian Coupula)
-        then it will cause Error: "NotImplementedError: float16 indexes are not supported"
-        Therefore I decide to set a min of float as float32.
+
+        20231103, Justyn:
+            pandas didn't suppot float16 engine,
+            and some of library will try to handle your column as index
+            (e.g. SDV, Gaussian Coupula)
+            then it will cause Error:
+            "NotImplementedError: float16 indexes are not supported"
+            Therefore I decide to set a min of float as float32.
     """
-    def __col_cast_check_string(col_data # : pd.Series
-                               ) -> str:
-        from dateutil.parser import parse
-        _cnt_date ,_cnt_datetime ,_cnt_category = 0,0,0
-        for _value in col_data.dropna():
+
+    def _col_cast_check_string(col_data: pd.Series) -> str:
+        cnt_date, cnt_datetime, cnt_category = 0, 0, 0
+        for value in col_data.dropna():
             try:
-                _parsed_col_data = parse(_value)
-                if  _parsed_col_data.hour   == 0\
-                and _parsed_col_data.minute == 0\
-                and _parsed_col_data.second == 0:
-                    _cnt_datetime += 1
+                parsed_col_data = parse(value)
+                if parsed_col_data.hour == 0\
+                        and parsed_col_data.minute == 0\
+                        and parsed_col_data.second == 0:
+                    cnt_datetime += 1
                 else:
-                    _cnt_date += 1 
+                    cnt_date += 1
+            # TODO Error assignment
+            #     I notices we should assign value via Error,
+            #     but have no idea how to avoid it here
             except (ValueError, TypeError):
-                _cnt_category += 1
-            
-        if _cnt_category >= max(_cnt_date, _cnt_datetime):
+                cnt_category += 1
+
+        if cnt_category >= max(cnt_date, cnt_datetime):
             return 'category'
-        elif _cnt_datetime >= 1:
+        elif cnt_datetime >= 1:
             return 'datetime'
         else:
             return 'date'
 
+    def _col_cast_check_numeric(
+        col_data: pd.Series,
+        force_type: str = ''
+    ) -> str:
 
-
-
-    def __col_cast_check_numeric(col_data  # : pd.Series
-                                ,force_type  : str = ''
-                                ) -> str:
-        from pandas.api.types import is_integer_dtype ,is_float_dtype
-        import numpy as np
-
-        _type_int_ranges = {
-            'int8'  : (np.iinfo(np.int8 ).min ,np.iinfo(np.int8 ).max)
-           ,'int16' : (np.iinfo(np.int16).min ,np.iinfo(np.int16).max)
-           ,'int32' : (np.iinfo(np.int32).min ,np.iinfo(np.int32).max)
-           ,'int64' : (np.iinfo(np.int64).min ,np.iinfo(np.int64).max)
+        type_int_ranges = {
+            'int8': (np.iinfo(np.int8).min, np.iinfo(np.int8).max),
+            'int16': (np.iinfo(np.int16).min, np.iinfo(np.int16).max),
+            'int32': (np.iinfo(np.int32).min, np.iinfo(np.int32).max),
+            'int64': (np.iinfo(np.int64).min, np.iinfo(np.int64).max)
         }
-        _type_float_ranges = {
-            'float32': (np.finfo(np.float32).min ,np.finfo(np.float32).max)
-           ,'float64': (np.finfo(np.float64).min ,np.finfo(np.float64).max)
+        type_float_ranges = {
+            'float32': (np.finfo(np.float32).min, np.finfo(np.float32).max),
+            'float64': (np.finfo(np.float64).min, np.finfo(np.float64).max)
         }
 
-        _col_min = 0.0 if np.all(np.isnan(col_data)) else np.nanmin(col_data)
-        _col_max = 0.0 if np.all(np.isnan(col_data)) else np.nanmax(col_data)
-        if   is_integer_dtype(col_data) or force_type.startswith('int'):
-            for _dtype, (_min ,_max) in _type_int_ranges.items():
-                if _min < _col_min <= _col_max < _max:
-                    return _dtype
+        col_min = 0.0 if np.all(np.isnan(col_data)) else np.nanmin(col_data)
+        col_max = 0.0 if np.all(np.isnan(col_data)) else np.nanmax(col_data)
+        if is_integer_dtype(col_data) or force_type.startswith('int'):
+            for dtype, (min, max) in type_int_ranges.items():
+                if min < col_min <= col_max < max:
+                    return dtype
         elif is_float_dtype(col_data) or force_type.startswith('float'):
-            for _dtype, (_min ,_max) in _type_float_ranges.items():
-                if _min < _col_min <= _col_max < _max:
-                    return _dtype
+            for dtype, (_min, _max) in type_float_ranges.items():
+                if min < col_min <= col_max < max:
+                    return dtype
         else:
-            return 'numeric-other' # already is_numeric_dtype(col_data)
+            # already is_numeric_dtype(col_data)
+            return 'numeric-other'
 
-
-
-    def __col_cast_check(col_data # : pd.Series
-                        ) -> str:
-        from pandas.api.types import is_string_dtype ,is_numeric_dtype
+    def _col_cast_check(col_data: pd.Series) -> str:
         if is_string_dtype(col_data):
-            return __col_cast_check_string( col_data)
+            return _col_cast_check_string(col_data)
         elif is_numeric_dtype(col_data):
-            return __col_cast_check_numeric(col_data)
+            return _col_cast_check_numeric(col_data)
         else:
             return 'error'
-
-
 
     if not dict_dtype:
         dict_dtype = {}
 
-    for _col_name, _col_data in df_data.items():
-        _col_data.dropna(inplace=True)
-        if _col_name in dict_dtype:
-            # print(f"{_col_name} as {str(dict_dtype[_col_name])}")
-            ####### ####### ####### ####### ####### ######
-            ####### Change float16 to float32
-            if dict_dtype[_col_name].lower() == 'float16':
-                dict_dtype[_col_name] = 'float32'
-                print(f"df_cast_check: The dtype for '{_col_name}' has been changed from 'float16' to 'float32' due to compatibility issues.")
+    for col_name, col_data in df_data.items():
+        col_data.dropna(inplace=True)
+        if col_name in dict_dtype:
+            # print(f"{col_name} as {str(dict_dtype[col_name])}")
+            # Forced change float16 to float32
+            if dict_dtype[col_name].lower() == 'float16':
+                dict_dtype[col_name] = 'float32'
+                print(
+                    f"Util - df_cast_check: The dtype for '{col_name}' "
+                    f"has been changed from 'float16' to 'float32' "
+                    "due to compatibility issues."
+                )
 
-            _force_type = dict_dtype[_col_name].lower()
+            force_type = dict_dtype[col_name].lower()
 
-            ####### ####### ####### ####### ####### ######
-            ####### Special handle if already been defined.
-            if _force_type in ['category' ,'date' ,'datetime']:
-                dict_dtype[_col_name] = _force_type
-            elif _force_type in ['int' ,'float']:
-                ####### ####### ####### ####### ####### ######
-                ####### If only defined int/float but no digits.
-                dict_dtype[_col_name] = __col_cast_check_numeric(_col_data ,_force_type)
-            elif _force_type.startswith('int') or _force_type.startswith('float'):
-                dict_dtype[_col_name] = _force_type
+            # Special handle if already been defined.
+            if force_type in ['category', 'date', 'datetime']:
+                dict_dtype[col_name] = force_type
+            elif force_type in ['int', 'float']:
+                # If only defined int/float but no digits.
+                dict_dtype[col_name] = _col_cast_check_numeric(
+                    col_data,
+                    force_type
+                )
+            elif force_type.startswith('int') or \
+                    force_type.startswith('float'):
+                dict_dtype[col_name] = force_type
             else:
-                raise ValueError('\n'.join([f"df_cast_check: Unsupported force dtype, now is {_force_type}."
-                                           ,f"We only support category/date/datetime/int-/float-."
-                                           ]))
+                # TODO Error.py
+                raise ValueError('\n'.join([
+                    f"Util - df_cast_check: "
+                    f"Unsupported force dtype, "
+                    f"now is {force_type}.",
+                    f"We only support "
+                    f"category/date/datetime/int-/float-."
+                ]))
         else:
-            ####### ####### ####### ####### ####### ######
-            ####### Otherwise determine by extreme value.
-            dict_dtype[_col_name] = __col_cast_check(_col_data)
+            # Otherwise determine by extreme value.
+            dict_dtype[col_name] = _col_cast_check(col_data)
 
     return dict_dtype

--- a/PETsARD/util/df_casting.py
+++ b/PETsARD/util/df_casting.py
@@ -1,46 +1,52 @@
-####### ####### ####### ####### ####### ######
-# Downcast in pandas df                      #
-####### ####### ####### ####### ####### ######
-# [TODO] avoid already have a category as ''
-def df_casting(df_data  # : pd.DataFrame
-              ,dict_dtype : dict         = None
-              ): # -> pd.DataFrame
+import numpy as np
+import pandas as pd
+
+from . import df_cast_check
+
+
+def df_casting(
+    df_data: pd.DataFrame,
+    dict_dtype: dict = None
+) -> pd.DataFrame:
     """
     Function for down-casting each columns of pd.DataFrame
+
+    TODO avoid already have a category as ''
+        But maybe this issue should handle by loader
     """
-    ####### ####### ####### ####### ####### ######
-    ####### Check the optimized dtype
+    # Check the optimized dtype
     if not dict_dtype:
         dict_dtype = {}
-    from . import df_cast_check
-    dict_dtype.update(df_cast_check(df_data ,dict_dtype))
+    dict_dtype.update(df_cast_check(df_data, dict_dtype))
 
-    import numpy as np
-    _type_numeric = {
-         'int8'   : np.int8
-        ,'int16'  : np.int16
-        ,'int32'  : np.int32
-        ,'int64'  : np.int64
-        ,'float32': np.float32
-        ,'float64': np.float64
+    type_numeric = {
+        'int8': np.int8,
+        'int16': np.int16,
+        'int32': np.int32,
+        'int64': np.int64,
+        'float32': np.float32,
+        'float64': np.float64
     }
-    for _col_name, _col_data in df_data.items():
-        if _col_name in dict_dtype:
-            _col_dtype_new = dict_dtype[_col_name]
-            ####### ####### ####### ####### ####### ######
-            ####### Category
-            if   _col_dtype_new == 'category':
-                df_data[_col_name] = _col_data.astype(_col_dtype_new)
-            ####### ####### ####### ####### ####### ######
-            ####### Date/Datetime
-            elif _col_dtype_new == 'date':
-                df_data[_col_name] = pd.to_datetime(_col_data , errors='coerce').dt.date
-            elif _col_dtype_new == 'datetime':
-                df_data[_col_name] = pd.to_datetime(_col_data , errors='coerce')
-            ####### ####### ####### ####### ####### ######
-            ####### Numeric
-            elif _col_dtype_new.startswith('int'  )\
-              or _col_dtype_new.startswith('float'):
-                df_data[_col_name] = _col_data.astype(_type_numeric[_col_dtype_new])
+    for col_name, col_data in df_data.items():
+        if col_name in dict_dtype:
+            col_dtype_new = dict_dtype[col_name]
+            # Category
+            if col_dtype_new == 'category':
+                df_data[col_name] = col_data.astype(col_dtype_new)
+            # Date/Datetime
+            elif col_dtype_new == 'date':
+                df_data[col_name] = pd.to_datetime(
+                    col_data,
+                    errors='coerce'
+                ).dt.date
+            elif col_dtype_new == 'datetime':
+                df_data[col_name] = pd.to_datetime(
+                    col_data,
+                    errors='coerce'
+                )
+            # Numeric
+            elif col_dtype_new.startswith('int') or \
+                    col_dtype_new.startswith('float'):
+                df_data[col_name] = col_data.astype(
+                    type_numeric[col_dtype_new])
     return df_data
-


### PR DESCRIPTION
Util + Processor parts。這個 branch 只：

- 修改 import 順序
- 調整排版、確保通過 autopep8

基本上不涉及變數名稱優化（但底線相關的變數也會一併改動）。

- For Util: 兩個工具跟一個 Error.py 的備註，這個最單純

- For Processor: @alexchen830 PEP8 規定 library 的導入須按照三個分組：

1. 標準庫 (Python 原生)
2. 相關第三方庫
3. 本地庫

每個分組間又各自要一行隔開，然後才是兩行隔開到 code。我只改這點、然後按下 autopep8 ~
另外 86 這個 branch 上面好像沒有 HyperProcessor 跟 Mediator，看你要不要自己改了送給 Miles 
https://peps.python.org/pep-0008/#imports

不過 @mileschangmoda 我發現 PEP8 要求 library import 是在註解跟 docstring 之後耶 (Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants)，我們現在是把模組功能寫在該 class 內部，你有建議更動、還是我們現在這樣 OK？