### PR TITLE
20240206, fix init config effective

### DIFF
--- a/PETsARD/processor/base.py
+++ b/PETsARD/processor/base.py
@@ -122,8 +122,11 @@ class Processor:
         self.rng = np.random.default_rng()
 
         # initialise the dict
+        col_dict = {
+            col: None for col in self._metadata['col'].keys()
+        }
         self._config: dict = {
-            processor: {} for processor in self._default_processor.keys()
+            processor: deepcopy(col_dict) for processor in self._default_processor.keys()
         }
 
         self.set_config(config=config)


### PR DESCRIPTION
發現在起 processor 的時候塞 config 會沒有執行，經過 peer-coding 找到原因並修正

`
processor = PETsARD.processor.Processor(
    metadata=loader.metadata,
    config=processor_config
)
`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206530892558655