### PR TITLE
20240206, #146 [05] Config for Loader/Splitter

### DIFF
--- a/PETsARD/config.py
+++ b/PETsARD/config.py
@@ -19,7 +19,7 @@ class Sequence:
         """  
         Args:
             sequence (list, optional):
-                The user defined sequence of modules.
+                The user defined sequence of modules in the experiment.
 
         Attributes:
             default_sequence (list):
@@ -52,6 +52,8 @@ class Config:
         Args:
             filename (str)
                 The filename of config file.
+            sequence (list. Optional):
+                The user defined sequence of modules in the experiment.
         """
         self.config:      queue.Queue = queue.Queue()
         self.module_flow: queue.Queue = queue.Queue()
@@ -160,7 +162,7 @@ class Status:
         """
         Args:
             sequence (list. Optional):
-                The sequence of modules in the experiment.
+                The user defined sequence of modules in the experiment.
 
         Attributes:
             sequence (list):


### PR DESCRIPTION
Config 類型建立，並支援 Loader, Splitter 的 Config

1. `_set_flow()` 用 `queue.Queue()` 先進先出，用 DFS (`_set_flow_dfs`) 排成一維陣列

2. 有三個一維陣列：Operator (`self.config`), module (`self.module_flow`), expt_flow (`self.expt_flow`) 供 Executor 使用

3. Splitter 需要用 `_splitter_handler()` 處理。這是因為 Splitter 有兩個參數：
  - `train_split_ratio`: 切 train/validation 的比例。預設為 0.8
  - `num_samples`: 切幾份。預設為 1

如果 `num_samples` 設定為多種切分，則 Splitter 這步其實代表要做【Splitter 實驗組數】x【各實驗內的 num_samples 切分數】。跟 @itfang-app 有討論過，這一步可以拆成 N 個 `Splitter(num_samples = 1)`，所以實現為 `_splitter_handler()` ：

- 原 config

```
{'Loader': {'adult': {...}},
 'Splitter': {'0.5': {num_samples=2, train_split_ratio=0.5},
                '0.8': {num_samples=3, train_split_ratio=0.8}}
 'Processor': {'missing-drop': {...}}}
```

- `_splitter_handler()` 轉換後

```
{'Loader': {'adult': {...}},
 'Splitter': {'0.5_[1|2]': {num_samples=1, train_split_ratio=0.5},
                 '0.5_[2|2]': {num_samples=1, train_split_ratio=0.5},
                 '0.8_[1|3]': {num_samples=1, train_split_ratio=0.8},
                 '0.8_[2|3]': {num_samples=1, train_split_ratio=0.8},
                 '0.8_[3|3]': {num_samples=1, train_split_ratio=0.8}},
 'Processor': {'missing-drop': {...}}}
```

