### PR TITLE
20240207, #146 [07] Status for no tag needs in Operator

### DIFF
--- a/PETsARD/config.py
+++ b/PETsARD/config.py
@@ -196,12 +196,7 @@ class Status:
         temp['operator'] = operator
         self.status[module] = deepcopy(temp)
 
-        if module == 'Splitter':
-            curr_exist_index: list = [
-                idx for value in operator.splitter.index.values()
-                for idx in value['train']
-            ]
-            self.exist_index = list(set(self.exist_index + curr_exist_index))
+        # TODO remove exist_index from previous Splitter
 
     def get_input_from_prev(self, module: str) -> dict:
         """


### PR DESCRIPTION
這張需要等 PR #220 

改動在於增加了 `Status.get_input_from_prev(module)` 方法，會去

1. 讀目前 module 在 sequence 上面前一個 module ( `prev_module`)
2. 依照目前 module 所需要的 `.run()` input 來組合一個 dict 回傳

搭配 Operator 改動 4d7ebce023c635aaddacc755692ba950caa88dee
這樣 Executor 就可以使用以下的方法

```
while cfg.config.qsize() > 0:
    operator = cfg.config.get()
    operator.run(**sts.get_input_from_prev(module=module))
    sts.put(module, expt, operator)
```

就不需要靠 Operator 操作 tag