### PR TITLE
20240322, Fix Processor default_process typo

### DIFF
--- a/PETsARD/processor/base.py
+++ b/PETsARD/processor/base.py
@@ -61,7 +61,7 @@ class Processor:
             'outlier': {
                 'numerical': OutlierIQR,
                 'categorical': lambda: None,
-                'datatime': OutlierIQR,
+                'datetime': OutlierIQR,
                 'object': lambda: None
             },
             'encoder': {


### PR DESCRIPTION
- Fixation
    - PETsARD\processor\base.py
        - datatime should be datetime - 11549c7371af10ca93ef4d815300206eea1e3bb6 