### PR TITLE
20240328, SAVE_REPORT_AVAILABLE_MODULE

### DIFF
--- a/PETsARD/reporter/reporter.py
+++ b/PETsARD/reporter/reporter.py
@@ -136,6 +136,7 @@ class ReporterBase(ABC):
         'Describer',
         'Reporter',
     ]
+    SAVE_REPORT_AVAILABLE_MODULE: list = ['Evaluator', 'Describer']
 
     def __init__(self, config: dict):
         """


### PR DESCRIPTION
修正找不到 SAVE_REPORT_AVAILABLE_MODULE 的問題。應該是 #401 在解衝突階段的錯誤，才沒有被 pytest 抓到

![image](https://github.com/nics-tw/PETsARD/assets/8596186/dbb8ddf0-b215-4f53-87ac-7b01a992cfdb)

經修改後可以正確執行以下出報告

```Python
from PETsARD import (
    Loader, Describer, Reporter
)


load = Loader(filepath='benchmark://adult-income',)
load.load()

desc = Describer(config={'method': 'default'},)
desc.create(data={'data': load.data,})
desc.eval()
desc.get_global()

rpt = Reporter(method='save_report',granularity='global')
rpt.create(data={('Describer', 'test_[global]'): desc.get_global(),})
rpt.report()
```


- Fixed 
    - PETsARD\reporter\reporter.py
        - 加回去 SAVE_REPORT_AVAILABLE_MODULE - 3f408120bc39fa7194ff4ab5f4980a9f75d63adb 
