### PR TITLE
fix: correct typo of diff in mlutility

### DIFF
--- a/PETsARD/evaluator/mlutlity.py
+++ b/PETsARD/evaluator/mlutlity.py
@@ -446,7 +446,7 @@ class MLWorker:
                                    'syn_std': safe_round(np.std(syn_value))},
                                   index=[0])
 
-        compare_df['pct_change'] = safe_round(
+        compare_df['diff'] = safe_round(
              compare_df['syn_mean'] - compare_df['ori_mean'])
 
         return compare_df


### PR DESCRIPTION
#516 遺漏的

- fix
    - PETsARD/evaluator/mlutility.py
        - correct typo of `diff` in `mlutility` - 62595f65ca6fdf4b6cf5abb2ef189cab8f761468 