### PR TITLE
bug: Remove high cardinality columns (>= n_rows/10) to avoid MemeryError by OHE

### DIFF
--- a/PETsARD/evaluator/mlutlity.py
+++ b/PETsARD/evaluator/mlutlity.py
@@ -232,8 +232,8 @@ class MLWorker:
                     data_ori = data_ori.drop(columns=col)
                     data_syn = data_syn.drop(columns=col)
                     data_test = data_test.drop(columns=col)
-                    if col in cat_col:
-                        cat_col = np.delete(cat_col, np.where(cat_col == col))
+
+                    cat_col = np.delete(cat_col, np.where(cat_col == col))
 
             # One-hot encoding
             ohe = OneHotEncoder(


### PR DESCRIPTION
Success evaluation after remove high cardinality

![image](https://github.com/nics-tw/PETsARD/assets/8596186/e1f2a7f2-146e-4054-8ee6-e5f368d2d5b6)

---

- feat:
    - PETsARD/evaluator/mlutility.py
        - fit OHE by both ori and ctrl for record all of possible category - 8769e848862c2114e4f4859a4dc5cf2f7544576d 
        - remove column when cardinality is too high - 40fefc5f43476dc7ff9f5ac5dc678c7f90a72519 

- test:
    - demo/dev/Issue556.ipynb
        - create Issue556.ipynb - 8977364c0fd635b86129c4d80d0fba5b94fab06c 
        - record success solved - 71ea0e28048d3dd3963738e23614ee8967997917 
        - remove Issue556.ipynb - 94a51cd4c1ee911f8f9816a6abc3007633e1efac 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207364307920533