### PR TITLE
bug: Describer inherit EvaluatorBase

### DIFF
--- a/PETsARD/evaluator/describer.py
+++ b/PETsARD/evaluator/describer.py
@@ -1,11 +1,12 @@
 import pandas as pd
 import numpy as np
 
+from PETsARD.evaluator.evaluator_base import EvaluatorBase
 from PETsARD.error import ConfigError
 from PETsARD.util import safe_round
 
 
-class Describer:
+class Describer(EvaluatorBase):
     """
     Interface class for Describers.
 


### PR DESCRIPTION
Successfully use Describer in YAML

![image](https://github.com/nics-tw/PETsARD/assets/8596186/6f8eac8b-7d08-440d-889e-f5853c79dc8d)

---

- bug:
    - PETsARD/evaluator/describer.py
        - inherit EvaluatorBase - 442d66f635d585570884ae1c12e7623e92281d91 