### PR TITLE
fix: update col_after_preproc in columwise _adjust_metadata()

### DIFF
--- a/PETsARD/processor/base.py
+++ b/PETsARD/processor/base.py
@@ -684,10 +684,18 @@ class Processor:
                 raise ConfigError(f'{col} is not in the metadata.')
 
             dtype_after_preproc: str = optimize_dtype(data)
+            infer_dtype_after_preproc: str = \
+                safe_infer_dtype(safe_dtype(dtype_after_preproc))
             self._metadata.metadata['col'][col]['dtype_after_preproc'] = \
                 dtype_after_preproc
             self._metadata.metadata['col'][col]['infer_dtype_after_preproc'] = \
-                safe_infer_dtype(safe_dtype(dtype_after_preproc))
+                infer_dtype_after_preproc
+
+            if 'col_after_preproc' in self._metadata.metadata:
+                self._metadata.metadata['col_after_preproc'][col]['dtype_after_preproc'] = \
+                    dtype_after_preproc
+                self._metadata.metadata['col_after_preproc'][col]['infer_dtype_after_preproc'] = \
+                    infer_dtype_after_preproc
         elif mode == 'global':
             if not isinstance(data, pd.DataFrame):
                 raise ConfigError(


### PR DESCRIPTION
- fix
    - PETsARD/processor/base.py
        - update col_after_preproc in columwise _adjust_metadata() - 1d949034d4bd5898cec94a81ff9a4cfb3be2ec6a 

- style
    - PETsARD/processor/base.py
        - PEP8 - 864cb71518e6a76dcc48848134163f38e2d2b0bf 

---

Evidence:

```
---
Splitter:
    p80:
        method: custom_data
        filepath:
            ori: expt/20240416_exptAB_Loader[olist]_Splitter[p80_[1-1]_[train]].csv
            control: expt/20240416_exptAB_Loader[olist]_Splitter[p80_[1-1]_[validation]].csv
        column_types:
            datetime:
                - order_purchase_timestamp
                - order_approved_at
                - order_delivered_carrier_date
                - order_delivered_customer_date
                - order_estimated_delivery_date
                - shipping_limit_date

Preprocessor:
    default-sdv:
        method: default

Synthesizer:

    sdv-gaussiancopula:
        method: sdv-gaussiancopula

Postprocessor:
    default-sdv:
        method: default

Reporter:
    save_data:
        method: save_data
        output: expt/20240416_exptAB
        source:
            - 'Postprocessor'
...
```

![image](https://github.com/nics-tw/PETsARD/assets/8596186/0462bdaa-674c-4a3d-9d2b-2d02bd12fcd2)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207377812913883