### PR TITLE
docs: remove cape from authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ name = "petsard"
 version = "0.12.0"
 description = "Facilitates data generation algorithm and their evaluation processes"
 authors = [
-    "NICS CAPE <cape@nics.nat.gov.tw>",
     "alexchen830 <alexchen830@gmail.com>",
     "matheme-justyn <matheme.justyn@gmail.com>"
 ]


### PR DESCRIPTION
- docs
    - remove cape from authors 6568918af75add39c3e70c9e329f28f6b12e777c 