### PR TITLE
fix: correct parameter extraction for sub-processors in Processor

### DIFF
--- a/doc_site/content/docs/tutorial/use-cases/data-preprocessing/encoding-category.md
+++ b/doc_site/content/docs/tutorial/use-cases/data-preprocessing/encoding-category.md
@@ -52,14 +52,12 @@ In the `encoder` block, we apply different encoding strategies for three fields:
 ```yaml
 Preprocessor:
   encoding-custom:
-    method: 'default'
     sequence:
       - 'encoder'
-    config:
-      encoder:
-        workclass: 'encoding_uniform'
-        occupation: 'encoding_label'
-        native-country: 'encoding_onehot'
+    encoder:
+      workclass: 'encoding_uniform'
+      occupation: 'encoding_label'
+      native-country: 'encoding_onehot'
 ```
 
 ## Encoding Methods

--- a/doc_site/content/docs/tutorial/use-cases/data-preprocessing/encoding-category.zh-tw.md
+++ b/doc_site/content/docs/tutorial/use-cases/data-preprocessing/encoding-category.zh-tw.md
@@ -52,14 +52,12 @@ Reporter:
 ```yaml
 Preprocessor:
   encoding-custom:
-    method: 'default'
     sequence:
       - 'encoder'
-    config:
-      encoder:
-        workclass: 'encoding_uniform'
-        occupation: 'encoding_label'
-        native-country: 'encoding_onehot'
+    encoder:
+      workclass: 'encoding_uniform'
+      occupation: 'encoding_label'
+      native-country: 'encoding_onehot'
 ```
 
 ## 編碼處理方法

--- a/doc_site/content/docs/tutorial/use-cases/data-preprocessing/handling-missing.md
+++ b/doc_site/content/docs/tutorial/use-cases/data-preprocessing/handling-missing.md
@@ -59,14 +59,12 @@ In the `missing` section, three fields are customized: missing values in the `wo
 ```yaml
 Preprocessor:
   missing-custom:
-    method: 'default'
-    config:
-      missing:
-        workclass: 'missing_drop'
-        occupation: 'missing_mode'
-        native-country:
-          method: 'missing-simple'
-          value: 'Galactic Empire'
+    missing:
+      workclass: 'missing_drop'
+      occupation: 'missing_mode'
+      native-country:
+        method: 'missing-simple'
+        value: 'Galactic Empire'
 ```
 
 ## Missing Value Handling Methods

--- a/doc_site/content/docs/tutorial/use-cases/data-preprocessing/handling-missing.zh-tw.md
+++ b/doc_site/content/docs/tutorial/use-cases/data-preprocessing/handling-missing.zh-tw.md
@@ -60,14 +60,12 @@ Reporter:
 ```yaml
 Preprocessor:
   missing-custom:
-    method: 'default'
-    config:
-      missing:
-        workclass: 'missing_drop'
-        occupation: 'missing_mode'
-        native-country:
-          method: 'missing-simple'
-          value: 'Galactic Empire'
+    missing:
+      workclass: 'missing_drop'
+      occupation: 'missing_mode'
+      native-country:
+        method: 'missing-simple'
+        value: 'Galactic Empire'
 ```
 
 ## 遺失值處理方法

--- a/petsard/operator.py
+++ b/petsard/operator.py
@@ -323,11 +323,7 @@ class PreprocessorOperator(BaseOperator):
                 An instance of the Processor class initialized with the provided configuration.
         """
         self.logger.debug("Initializing processor")
-        self.processor = Processor(metadata=input["metadata"])
-
-        # for keep default but update manual only
-        self.logger.debug("Updating processor configuration")
-        self.processor.update_config(self._config)
+        self.processor = Processor(metadata=input["metadata"], config=self._config)
 
         if self._sequence is None:
             self.logger.debug("Using default processing sequence")

--- a/petsard/processor/scaler.py
+++ b/petsard/processor/scaler.py
@@ -222,12 +222,12 @@ class ScalerTimeAnchor(Scaler):
     Scale the data by time difference from a reference time series.
     """
 
-    def __init__(self, unit: str = "D") -> None:
+    def __init__(self, reference: str, unit: str = "D") -> None:
         super().__init__()
         if unit not in ["D", "S"]:
             raise ValueError("unit must be either 'D'(days) or 'S'(seconds)")
-        self.unit = unit
-        self.reference_series = None
+        self.unit: str = unit
+        self.reference: str = reference
 
     def set_reference_time(self, reference_series: pd.Series) -> None:
         """Set reference series for row-wise time difference calculation"""
@@ -237,15 +237,13 @@ class ScalerTimeAnchor(Scaler):
 
     def _fit(self, data: np.ndarray) -> None:
         """Validate data type and reference"""
-        if not pd.api.types.is_datetime64_any_dtype(data):
-            raise ValueError("Data must be in datetime format")
-        if self.reference_series is None:
-            raise ValueError("Reference series not set")
-        if len(data) != len(self.reference_series):
-            raise ValueError("Target and reference must have same length")
 
     def _transform(self, data: np.ndarray) -> np.ndarray:
         """Transform to time differences"""
+
+        if len(data) != len(self.reference_series):
+            raise ValueError("Target and reference must have same length")
+
         delta = pd.Series(data.ravel()) - self.reference_series
 
         if self.unit == "D":

--- a/petsard/util/dtype_operations.py
+++ b/petsard/util/dtype_operations.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import warnings
 from typing import Dict, Union
 
@@ -16,14 +15,6 @@ from pandas.api.types import (
 
 from petsard.error import ConfigError
 from petsard.util.params import ALLOWED_COLUMN_TYPES, OPTIMIZED_DTYPES
-
-# 設定 logging
-logging.basicConfig(
-    level=logging.INFO,
-    stream=sys.stdout,
-    format="[%(levelname).1s %(asctime)s] %(message)s",
-    datefmt="%Y%m%d %H:%M:%S",
-)
 
 # 常數定義
 NUMERIC_MAP: dict[str, int] = {
@@ -65,6 +56,7 @@ def safe_dtype(
     Raises:
         TypeError: If the input data type is not supported.
     """
+
     dtype_name: str = ""
 
     if isinstance(dtype, np.dtype):
@@ -268,6 +260,8 @@ def safe_astype(
     """
     Safely cast a pandas Series to a given dtype.
     """
+    logger = logging.getLogger(f"PETsARD.{__name__}")
+
     data_dtype_name: str = safe_dtype(col.dtype)
     declared_dtype_name: str = safe_dtype(declared_dtype)
 
@@ -276,7 +270,7 @@ def safe_astype(
         colname = col.name
 
     if data_dtype_name == "float16":
-        logging.info(
+        logger.info(
             f"dtype {data_dtype_name} change to float32 first"
             + "for pandas only support float32 above.",
         )
@@ -305,7 +299,7 @@ def safe_astype(
         if declared_dtype_name == "float16" and (
             is_integer_dtype(data_dtype_name) or is_float_dtype(data_dtype_name)
         ):
-            logging.info(
+            logger.info(
                 f"declared dtype {declared_dtype_name} "
                 + "will changes to float32 "
                 + "for pandas only support float32 above.",
@@ -372,7 +366,7 @@ def safe_astype(
         else:
             col = col.astype(declared_dtype_name)
 
-        logging.info(
+        logger.info(
             f"{colname} changes data dtype from "
             + f"{data_dtype_name} to {declared_dtype_name} "
             + "for metadata alignment.",


### PR DESCRIPTION
close #677 

- fix
  - correct parameter extraction for sub-processors in Processor - 72b5ab932eb9c0a9334c0f08f7c41c39c7cf9fd9
    - operator.py: Directly assign config when initialization
    - processor/base.py:
      - Construct `MediatorMap` and integrated `self._mediator` in one dictionary. Handling parameters of sub-processors in `.update_config()`. 
      - Remove `print_config` in `get_config()`
      - Delay `Processor.fit()` `Mediator.fit()` to `Processor.transform()` due to date convert situation issue
    - processor/encoder.py:
      - `EncoderDate()`: `._format_output()` should apply even in `._apply_replacement_rules()`
      - protect `transform()` output date range to avoid overflow `pd.Timestampe` min/max limit
    - processor/scaler.py:
      - `ScalerTimeAnchor()`: fix reference as args in `__init__`
      - Move basic logic from `MediatorScaler()` to `ScalerTimeAnchor()`
    - processor/mediator.py:
      - Move basic logic from `MediatorScaler()` to `ScalerTimeAnchor()`
    - processor/date_format_converter.py: Considering more edge case
    - util/dtyp_operations.py: Combined logging in PETsARD log
    - tests/processor/encoder/test_encoder_date.py, test_data_format_converter.py: enrich testing
    - docs (handling-missing, encoding-category in both en and zh-tw): fix customized YAML sample

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209361066161176