### PR TITLE
refactor(core): rename operator module to adapter pattern

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -30,7 +30,7 @@ The `.ai/` directory provides:
 │   ├── reporter.md             # Reporting module design
 │   ├── constrainer.md          # Data constraint module design
 │   ├── executor.md             # Execution orchestration design
-│   ├── operator.md             # Data operation module design
+│   ├── adapter.md              # Data operation module design
 │   └── config.md               # Configuration module design
 ├── scripts/                     # Development automation scripts
 │   ├── development-assistant.py # Code-documentation sync checker

--- a/.ai/functional_design/adapter.md
+++ b/.ai/functional_design/adapter.md
@@ -1,27 +1,27 @@
-# Operator 模組功能設計文件
+# Adapter 模組功能設計文件
 
 ## 🎯 模組職責
 
-Operator 模組提供統一的操作器介面，將各個功能模組（Loader、Processor、Synthesizer 等）封裝為可執行的操作器，負責模組間的資料流轉、狀態管理和執行協調。
+Adapter 模組提供統一的適配器介面，將各個功能模組（Loader、Processor、Synthesizer 等）封裝為可執行的適配器，負責模組間的資料流轉、狀態管理和執行協調。
 
 ## 📋 核心功能
 
-### 1. 統一操作器介面
-- **BaseOperator**: 定義所有操作器的基礎介面
+### 1. 統一適配器介面
+- **BaseAdapter**: 定義所有適配器的基礎介面
 - **執行協調**: 統一的執行流程和錯誤處理
 - **輸入設定**: 標準化的輸入資料設定機制
 - **結果管理**: 統一的結果取得和元資料管理
 
 ### 2. 模組封裝
-- **LoaderOperator**: 資料載入操作器
-- **SplitterOperator**: 資料分割操作器
-- **PreprocessorOperator**: 資料前處理操作器
-- **SynthesizerOperator**: 資料合成操作器
-- **PostprocessorOperator**: 資料後處理操作器
-- **ConstrainerOperator**: 約束條件操作器
-- **EvaluatorOperator**: 資料評估操作器
-- **DescriberOperator**: 資料描述操作器
-- **ReporterOperator**: 結果報告操作器
+- **LoaderAdapter**: 資料載入適配器
+- **SplitterAdapter**: 資料分割適配器
+- **PreprocessorAdapter**: 資料前處理適配器
+- **SynthesizerAdapter**: 資料合成適配器
+- **PostprocessorAdapter**: 資料後處理適配器
+- **ConstrainerAdapter**: 約束條件適配器
+- **EvaluatorAdapter**: 資料評估適配器
+- **DescriberAdapter**: 資料描述適配器
+- **ReporterAdapter**: 結果報告適配器
 
 ### 3. 資料流管理
 - **依賴解析**: 自動解析模組間的資料依賴關係
@@ -31,24 +31,24 @@ Operator 模組提供統一的操作器介面，將各個功能模組（Loader�
 
 ### 4. 統一計時系統
 - **自動計時**: 透過 logging 機制自動記錄執行時間
-- **時間追蹤**: 記錄每個操作器的開始、結束和持續時間
+- **時間追蹤**: 記錄每個適配器的開始、結束和持續時間
 - **錯誤計時**: 支援錯誤情況下的計時記錄
-- **解耦設計**: 操作器保持獨立，不依賴外部狀態管理
+- **解耦設計**: 適配器保持獨立，不依賴外部狀態管理
 
 ## 🏗️ 架構設計
 
 ### 設計模式
-- **Template Method Pattern**: BaseOperator 定義執行模板
-- **Strategy Pattern**: 不同操作器實作不同策略
-- **Adapter Pattern**: 將功能模組適配為操作器介面
-- **Decorator Pattern**: 為操作器添加日誌和錯誤處理
+- **Template Method Pattern**: BaseAdapter 定義執行模板
+- **Strategy Pattern**: 不同適配器實作不同策略
+- **Adapter Pattern**: 將功能模組適配為適配器介面
+- **Decorator Pattern**: 為適配器添加日誌和錯誤處理
 
 ### 核心類別架構
 
-#### BaseOperator 抽象基類
+#### BaseAdapter 抽象基類
 ```python
-class BaseOperator:
-    """操作器基礎介面"""
+class BaseAdapter:
+    """適配器基礎介面"""
     
     def __init__(self, config: dict)
     def run(self, input: dict)                    # 模板方法（包含自動計時）
@@ -61,7 +61,7 @@ class BaseOperator:
 #### 統一計時機制
 ```python
 def run(self, input: dict):
-    """執行操作器並自動記錄時間"""
+    """執行適配器並自動記錄時間"""
     start_time = time.time()
     
     # 記錄開始時間
@@ -86,18 +86,18 @@ def run(self, input: dict):
         raise
 ```
 
-#### 具體操作器類別
+#### 具體適配器類別
 ```python
-class LoaderOperator(BaseOperator):
-    """資料載入操作器"""
+class LoaderAdapter(BaseAdapter):
+    """資料載入適配器"""
     def __init__(self, config: dict)
     def _run(self, input: dict)
     def set_input(self, status) -> dict
     def get_result(self) -> pd.DataFrame
     def get_metadata(self) -> SchemaMetadata
 
-class SynthesizerOperator(BaseOperator):
-    """資料合成操作器"""
+class SynthesizerAdapter(BaseAdapter):
+    """資料合成適配器"""
     def __init__(self, config: dict)
     def _run(self, input: dict)
     def set_input(self, status) -> dict
@@ -113,7 +113,7 @@ class SynthesizerOperator(BaseOperator):
 ### 整合優勢
 - **型別安全**: 使用 SchemaMetadata 提供強型別檢查
 - **功能增強**: 利用 Metadater 的豐富功能
-- **統一介面**: 所有操作器使用相同的元資料格式
+- **統一介面**: 所有適配器使用相同的元資料格式
 - **向後相容**: 保持現有 API 的相容性
 
 ### 具體改動
@@ -129,67 +129,67 @@ def get_metadata(self) -> SchemaMetadata: ...
 
 ## 📊 公開 API
 
-### BaseOperator API
+### BaseAdapter API
 ```python
-# 基礎操作器介面
-operator = SomeOperator(config_dict)
-operator.run(input_dict)                    # 執行操作器
-result = operator.get_result()              # 取得執行結果
-metadata = operator.get_metadata()          # 取得元資料
-input_dict = operator.set_input(status)     # 設定輸入資料
+# 基礎適配器介面
+adapter = SomeAdapter(config_dict)
+adapter.run(input_dict)                    # 執行適配器
+result = adapter.get_result()              # 取得執行結果
+metadata = adapter.get_metadata()          # 取得元資料
+input_dict = adapter.set_input(status)     # 設定輸入資料
 ```
 
-### 操作器生命週期
+### 適配器生命週期
 ```python
-# 1. 建立操作器
-operator = LoaderOperator({'method': 'csv', 'path': 'data.csv'})
+# 1. 建立適配器
+adapter = LoaderAdapter({'method': 'csv', 'path': 'data.csv'})
 
 # 2. 設定輸入
-input_data = operator.set_input(status)
+input_data = adapter.set_input(status)
 
-# 3. 執行操作器
-operator.run(input_data)
+# 3. 執行適配器
+adapter.run(input_data)
 
 # 4. 取得結果
-data = operator.get_result()
-metadata = operator.get_metadata()
+data = adapter.get_result()
+metadata = adapter.get_metadata()
 
 # 5. 更新狀態
-status.put(module_name, expt_name, operator)
+status.put(module_name, expt_name, adapter)
 ```
 
 ## 🔧 使用範例
 
-### 基本操作器使用
+### 基本適配器使用
 ```python
-from petsard.operator import LoaderOperator, SynthesizerOperator
+from petsard.adapter import LoaderAdapter, SynthesizerAdapter
 from petsard.config import Status, Config
 
 # 建立配置和狀態
 config = Config(yaml_config)
 status = Status(config)
 
-# 使用 LoaderOperator
-loader_op = LoaderOperator({'method': 'csv', 'path': 'data.csv'})
-loader_input = loader_op.set_input(status)
-loader_op.run(loader_input)
+# 使用 LoaderAdapter
+loader_adapter = LoaderAdapter({'method': 'csv', 'path': 'data.csv'})
+loader_input = loader_adapter.set_input(status)
+loader_adapter.run(loader_input)
 
 # 更新狀態
-status.put('Loader', 'load_data', loader_op)
+status.put('Loader', 'load_data', loader_adapter)
 
-# 使用 SynthesizerOperator
-synth_op = SynthesizerOperator({'method': 'sdv', 'model': 'GaussianCopula'})
-synth_input = synth_op.set_input(status)  # 自動從 status 取得前一步的資料
-synth_op.run(synth_input)
+# 使用 SynthesizerAdapter
+synth_adapter = SynthesizerAdapter({'method': 'sdv', 'model': 'GaussianCopula'})
+synth_input = synth_adapter.set_input(status)  # 自動從 status 取得前一步的資料
+synth_adapter.run(synth_input)
 
 # 取得結果
-synthetic_data = synth_op.get_result()
+synthetic_data = synth_adapter.get_result()
 ```
 
-### 自定義操作器
+### 自定義適配器
 ```python
-class CustomOperator(BaseOperator):
-    """自定義操作器範例"""
+class CustomAdapter(BaseAdapter):
+    """自定義適配器範例"""
     
     def __init__(self, config: dict):
         super().__init__(config)
@@ -217,10 +217,10 @@ class CustomOperator(BaseOperator):
 
 ### 錯誤處理和日誌
 ```python
-class RobustOperator(BaseOperator):
-    """具備完善錯誤處理的操作器"""
+class RobustAdapter(BaseAdapter):
+    """具備完善錯誤處理的適配器"""
     
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """使用裝飾器處理配置錯誤"""
         if 'required_param' not in self.config:
@@ -242,13 +242,13 @@ class RobustOperator(BaseOperator):
 ## 🧪 測試策略
 
 ### 單元測試
-- 各操作器的獨立功能測試
+- 各適配器的獨立功能測試
 - 輸入設定邏輯測試
 - 結果和元資料取得測試
 - 錯誤處理機制測試
 
 ### 整合測試
-- 操作器間資料流轉測試
+- 適配器間資料流轉測試
 - 狀態管理整合測試
 - 完整工作流程測試
 - 元資料一致性測試
@@ -256,26 +256,26 @@ class RobustOperator(BaseOperator):
 ### 測試範例
 ```python
 import pytest
-from petsard.operator import LoaderOperator
+from petsard.adapter import LoaderAdapter
 from petsard.config import Status, Config
 
-def test_loader_operator():
-    """測試 LoaderOperator 基本功能"""
+def test_loader_adapter():
+    """測試 LoaderAdapter 基本功能"""
     config = {'method': 'csv', 'path': 'test_data.csv'}
-    operator = LoaderOperator(config)
+    adapter = LoaderAdapter(config)
     
     # 測試初始化
-    assert operator.config == config
-    assert operator.module_name == "LoaderOp"
+    assert adapter.config == config
+    assert adapter.module_name == "LoaderAdapter"
     
     # 測試執行
     status = create_test_status()
-    input_data = operator.set_input(status)
-    operator.run(input_data)
+    input_data = adapter.set_input(status)
+    adapter.run(input_data)
     
     # 驗證結果
-    result = operator.get_result()
-    metadata = operator.get_metadata()
+    result = adapter.get_result()
+    metadata = adapter.get_metadata()
     
     assert isinstance(result, pd.DataFrame)
     assert isinstance(metadata, SchemaMetadata)
@@ -284,28 +284,28 @@ def test_loader_operator():
 ## 🔮 未來發展
 
 ### 功能增強
-- **非同步執行**: 支援非同步操作器執行
+- **非同步執行**: 支援非同步適配器執行
 - **批次處理**: 支援批次資料處理
 - **快取機制**: 實作智慧快取減少重複計算
 - **動態配置**: 支援執行時配置調整
 
 ### 效能最佳化
 - **記憶體管理**: 最佳化大型資料集的記憶體使用
-- **並行處理**: 支援操作器並行執行
+- **並行處理**: 支援適配器並行執行
 - **資料流最佳化**: 最佳化模組間資料傳遞
 - **懶載入**: 實作資料的懶載入機制
 
 ### 擴展性改善
-- **插件系統**: 支援第三方操作器插件
-- **配置範本**: 提供常用操作器配置範本
-- **監控介面**: 提供操作器執行監控
-- **除錯工具**: 提供操作器除錯和分析工具
+- **插件系統**: 支援第三方適配器插件
+- **配置範本**: 提供常用適配器配置範本
+- **監控介面**: 提供適配器執行監控
+- **除錯工具**: 提供適配器除錯和分析工具
 
 ## 📝 注意事項
 
 ### 設計原則
-1. **統一介面**: 所有操作器遵循相同的介面規範
-2. **單一職責**: 每個操作器專注於特定功能
+1. **統一介面**: 所有適配器遵循相同的介面規範
+2. **單一職責**: 每個適配器專注於特定功能
 3. **依賴注入**: 透過 Status 物件注入依賴
 4. **錯誤處理**: 完善的錯誤捕獲和處理機制
 
@@ -313,10 +313,10 @@ def test_loader_operator():
 1. **日誌記錄**: 記錄詳細的執行過程和狀態變化
 2. **資源管理**: 適當管理記憶體和系統資源
 3. **型別檢查**: 使用型別提示和檢查
-4. **文檔完整**: 為每個操作器提供完整文檔
+4. **文檔完整**: 為每個適配器提供完整文檔
 
 ### 常見問題
-1. **依賴順序**: 確保操作器執行順序正確
+1. **依賴順序**: 確保適配器執行順序正確
 2. **資料格式**: 確保模組間資料格式一致
 3. **元資料同步**: 保持元資料在模組間的一致性
 4. **記憶體洩漏**: 注意大型資料的記憶體管理
@@ -326,10 +326,10 @@ def test_loader_operator():
 ```python
 # 舊版
 from petsard.loader import Metadata
-metadata: Metadata = operator.get_metadata()
+metadata: Metadata = adapter.get_metadata()
 
 # 新版
 from petsard.metadater import SchemaMetadata
-metadata: SchemaMetadata = operator.get_metadata()
+metadata: SchemaMetadata = adapter.get_metadata()
 
 # API 使用基本保持不變，但內部實作使用 Metadater

--- a/.ai/functional_design/config.md
+++ b/.ai/functional_design/config.md
@@ -42,7 +42,7 @@ class Config:
 class Status:
     """執行狀態管理器"""
     
-    def put(self, module: str, expt: str, operator: BaseOperator)
+    def put(self, module: str, expt: str, adapter: BaseAdapter)
     def get_result(self, module: str) -> Union[dict, pd.DataFrame]
     def get_metadata(self, module: str = "Loader") -> SchemaMetadata
     def set_metadata(self, module: str, metadata: SchemaMetadata)
@@ -76,7 +76,7 @@ config.sequence    # 模組執行順序
 ### Status 類別 API
 ```python
 # 狀態管理
-status.put(module, expt, operator)           # 儲存模組狀態
+status.put(module, expt, adapter)            # 儲存模組狀態
 status.get_result(module)                    # 取得模組結果
 status.get_metadata(module)                  # 取得模組元資料
 status.set_metadata(module, metadata)        # 設定模組元資料
@@ -107,13 +107,13 @@ status = Status(config)
 
 # 執行流程
 while config.config.qsize() > 0:
-    operator = config.config.get()
+    adapter = config.config.get()
     module = config.module_flow.get()
     expt = config.expt_flow.get()
     
     # 執行模組
-    operator.run(operator.set_input(status))
-    status.put(module, expt, operator)
+    adapter.run(adapter.set_input(status))
+    status.put(module, expt, adapter)
 ```
 
 ### 元資料管理

--- a/.ai/functional_design/executor.md
+++ b/.ai/functional_design/executor.md
@@ -80,13 +80,13 @@ status = Status(config)
 ```python
 # 按順序執行所有模組
 while config.config.qsize() > 0:
-    operator = config.config.get()
+    adapter = config.config.get()
     module = config.module_flow.get()
     expt = config.expt_flow.get()
     
     # 執行模組
-    operator.run(operator.set_input(status))
-    status.put(module, expt, operator)
+    adapter.run(adapter.set_input(status))
+    status.put(module, expt, adapter)
     
     # 收集結果
     _set_result(module)

--- a/doc_site/content/docs/api/_index.md
+++ b/doc_site/content/docs/api/_index.md
@@ -23,7 +23,7 @@ sidebar:
 | [Evaluator](./evaluator) | `Evaluator` | `Evaluator(**kwargs)` | `create()`, `eval()` |
 | [Describer](./describer) | `Describer` | `Describer(**kwargs)` | `create()`, `eval()` |
 | [Reporter](./reporter) | `Reporter` | `Reporter(method, **kwargs)` | `create()`, `report()` |
-| [Operator](./operator) | `*Operator` | `*Operator(config)` | `run()`, `set_input()`, `get_result()` |
+| [Adapter](./adapter) | `*Adapter` | `*Adapter(config)` | `run()`, `set_input()`, `get_result()` |
 | [Config](./config) | `Config` | `Config(config_dict)` | Auto-processing during init |
 | [Status](./status) | `Status` | `Status(config)` | `put()`, `get_result()`, `create_snapshot()` |
 | [Utils](./utils) | Functions | Direct import | `load_external_module()` |
@@ -45,7 +45,7 @@ sidebar:
 - [Reporter](./reporter) - Results export and reporting
 
 ## System Components
-- [Operator](./operator) - Standardized execution wrappers for all modules
+- [Adapter](./adapter) - Standardized execution wrappers for all modules
 - [Config](./config) - Experiment configuration management
 - [Status](./status) - Pipeline state and progress tracking
 - [Utils](./utils) - Core utility functions and external module loading

--- a/doc_site/content/docs/api/_index.zh-tw.md
+++ b/doc_site/content/docs/api/_index.zh-tw.md
@@ -23,7 +23,7 @@ sidebar:
 | [Evaluator](./evaluator) | `Evaluator` | `Evaluator(**kwargs)` | `create()`, `eval()` |
 | [Describer](./describer) | `Describer` | `Describer(**kwargs)` | `create()`, `eval()` |
 | [Reporter](./reporter) | `Reporter` | `Reporter(method, **kwargs)` | `create()`, `report()` |
-| [Operator](./operator) | `*Operator` | `*Operator(config)` | `run()`, `set_input()`, `get_result()` |
+| [Adapter](./adapter) | `*Adapter` | `*Adapter(config)` | `run()`, `set_input()`, `get_result()` |
 | [Config](./config) | `Config` | `Config(config_dict)` | 初始化時自動處理 |
 | [Status](./status) | `Status` | `Status(config)` | `put()`, `get_result()`, `create_snapshot()` |
 | [Utils](./utils) | 函式 | 直接匯入 | `load_external_module()` |
@@ -45,7 +45,7 @@ sidebar:
 - [Reporter](./reporter) - 結果匯出和報告
 
 ## 系統組件
-- [Operator](./operator) - 所有模組的標準化執行包裝器
+- [Adapter](./adapter) - 所有模組的標準化執行包裝器
 - [Config](./config) - 實驗配置管理
 - [Status](./status) - 管線狀態和進度追蹤
 - [Utils](./utils) - 核心工具函式和外部模組載入

--- a/doc_site/content/docs/api/adapter.md
+++ b/doc_site/content/docs/api/adapter.md
@@ -1,5 +1,5 @@
 ---
-title: Operator
+title: Adapter
 type: docs
 weight: 61
 prev: docs/api/reporter
@@ -7,47 +7,47 @@ next: docs/api/config
 ---
 
 ```python
-petsard.operator
+petsard.adapter
 ```
 
-The Operator module provides wrapper classes that standardize the execution interface for all PETsARD pipeline components. Each operator encapsulates a specific module (Loader, Synthesizer, etc.) and provides consistent methods for configuration, execution, and result retrieval.
+The Adapter module provides wrapper classes that standardize the execution interface for all PETsARD pipeline components. Each adapter encapsulates a specific module (Loader, Synthesizer, etc.) and provides consistent methods for configuration, execution, and result retrieval.
 
 ## Design Overview
 
-The Operator system follows a decorator pattern, wrapping core modules with standardized interfaces for pipeline execution. This design ensures consistent behavior across all pipeline components while maintaining flexibility for module-specific functionality.
+The Adapter system follows a decorator pattern, wrapping core modules with standardized interfaces for pipeline execution. This design ensures consistent behavior across all pipeline components while maintaining flexibility for module-specific functionality.
 
 ### Key Principles
 
-1. **Standardization**: All operators implement the same base interface for consistent pipeline execution
-2. **Encapsulation**: Each operator wraps its corresponding module, handling configuration and execution details
-3. **Error Handling**: Comprehensive error logging and exception handling across all operators
+1. **Standardization**: All adapters implement the same base interface for consistent pipeline execution
+2. **Encapsulation**: Each adapter wraps its corresponding module, handling configuration and execution details
+3. **Error Handling**: Comprehensive error logging and exception handling across all adapters
 4. **Metadata Management**: Consistent metadata handling using the Metadater system
 
 ## Base Classes
 
-### `BaseOperator`
+### `BaseAdapter`
 
 ```python
-BaseOperator(config)
+BaseAdapter(config)
 ```
 
-Abstract base class defining the standard interface for all operators.
+Abstract base class defining the standard interface for all adapters.
 
 **Parameters**
-- `config` (dict): Configuration parameters for the operator
+- `config` (dict): Configuration parameters for the adapter
 
 **Methods**
-- `run(input)`: Execute the operator's functionality
+- `run(input)`: Execute the adapter's functionality
 - `set_input(status)`: Configure input data from pipeline status
-- `get_result()`: Retrieve the operator's output data
+- `get_result()`: Retrieve the adapter's output data
 - `get_metadata()`: Retrieve metadata associated with the output
 
-## Operator Classes
+## Adapter Classes
 
-### `LoaderOperator`
+### `LoaderAdapter`
 
 ```python
-LoaderOperator(config)
+LoaderAdapter(config)
 ```
 
 Wraps the Loader module for data loading operations.
@@ -63,10 +63,10 @@ Wraps the Loader module for data loading operations.
 - `get_result()`: Returns loaded DataFrame
 - `get_metadata()`: Returns SchemaMetadata for the loaded data
 
-### `SplitterOperator`
+### `SplitterAdapter`
 
 ```python
-SplitterOperator(config)
+SplitterAdapter(config)
 ```
 
 Wraps the Splitter module for data splitting operations.
@@ -81,10 +81,10 @@ Wraps the Splitter module for data splitting operations.
 - `get_result()`: Returns dict with 'train' and 'validation' DataFrames
 - `get_metadata()`: Returns updated SchemaMetadata with split information
 
-### `PreprocessorOperator`
+### `PreprocessorAdapter`
 
 ```python
-PreprocessorOperator(config)
+PreprocessorAdapter(config)
 ```
 
 Wraps the Processor module for data preprocessing operations.
@@ -98,10 +98,10 @@ Wraps the Processor module for data preprocessing operations.
 - `get_result()`: Returns preprocessed DataFrame
 - `get_metadata()`: Returns updated SchemaMetadata
 
-### `SynthesizerOperator`
+### `SynthesizerAdapter`
 
 ```python
-SynthesizerOperator(config)
+SynthesizerAdapter(config)
 ```
 
 Wraps the Synthesizer module for synthetic data generation.
@@ -114,10 +114,10 @@ Wraps the Synthesizer module for synthetic data generation.
 **Key Methods**
 - `get_result()`: Returns synthetic DataFrame
 
-### `PostprocessorOperator`
+### `PostprocessorAdapter`
 
 ```python
-PostprocessorOperator(config)
+PostprocessorAdapter(config)
 ```
 
 Wraps the Processor module for data postprocessing operations.
@@ -128,10 +128,10 @@ Wraps the Processor module for data postprocessing operations.
 **Key Methods**
 - `get_result()`: Returns postprocessed DataFrame
 
-### `ConstrainerOperator`
+### `ConstrainerAdapter`
 
 ```python
-ConstrainerOperator(config)
+ConstrainerAdapter(config)
 ```
 
 Wraps the Constrainer module for applying data constraints.
@@ -145,10 +145,10 @@ Wraps the Constrainer module for applying data constraints.
 **Key Methods**
 - `get_result()`: Returns constrained DataFrame
 
-### `EvaluatorOperator`
+### `EvaluatorAdapter`
 
 ```python
-EvaluatorOperator(config)
+EvaluatorAdapter(config)
 ```
 
 Wraps the Evaluator module for data quality assessment.
@@ -160,10 +160,10 @@ Wraps the Evaluator module for data quality assessment.
 **Key Methods**
 - `get_result()`: Returns dict of evaluation results by metric type
 
-### `DescriberOperator`
+### `DescriberAdapter`
 
 ```python
-DescriberOperator(config)
+DescriberAdapter(config)
 ```
 
 Wraps the Describer module for descriptive data analysis.
@@ -175,10 +175,10 @@ Wraps the Describer module for descriptive data analysis.
 **Key Methods**
 - `get_result()`: Returns dict of descriptive analysis results
 
-### `ReporterOperator`
+### `ReporterAdapter`
 
 ```python
-ReporterOperator(config)
+ReporterAdapter(config)
 ```
 
 Wraps the Reporter module for result export and reporting.
@@ -194,24 +194,24 @@ Wraps the Reporter module for result export and reporting.
 
 ## Usage Examples
 
-### Basic Operator Usage
+### Basic Adapter Usage
 
 ```python
-from petsard.operator import LoaderOperator
+from petsard.adapter import LoaderAdapter
 
-# Create and configure operator
+# Create and configure adapter
 config = {"filepath": "data.csv"}
-loader_op = LoaderOperator(config)
+loader_adapter = LoaderAdapter(config)
 
 # Set input (typically done by Executor)
-input_data = loader_op.set_input(status)
+input_data = loader_adapter.set_input(status)
 
 # Execute operation
-loader_op.run(input_data)
+loader_adapter.run(input_data)
 
 # Retrieve results
-data = loader_op.get_result()
-metadata = loader_op.get_metadata()
+data = loader_adapter.get_result()
+metadata = loader_adapter.get_metadata()
 ```
 
 ### Pipeline Integration
@@ -220,7 +220,7 @@ metadata = loader_op.get_metadata()
 from petsard.config import Config
 from petsard.executor import Executor
 
-# Operators are typically used through Config and Executor
+# Adapters are typically used through Config and Executor
 config_dict = {
     "Loader": {"load_data": {"filepath": "data.csv"}},
     "Synthesizer": {"synth": {"method": "sdv", "model": "GaussianCopula"}},
@@ -235,7 +235,7 @@ executor.run()
 ## Architecture Benefits
 
 ### 1. Consistent Interface
-- **Standardized methods**: All operators implement the same base interface
+- **Standardized methods**: All adapters implement the same base interface
 - **Predictable behavior**: Consistent execution patterns across all modules
 
 ### 2. Error Handling
@@ -247,7 +247,7 @@ executor.run()
 - **Data flow**: Standardized data passing between pipeline stages
 
 ### 4. Modularity
-- **Separation of concerns**: Each operator handles one specific functionality
-- **Extensibility**: Easy to add new operators for new modules
+- **Separation of concerns**: Each adapter handles one specific functionality
+- **Extensibility**: Easy to add new adapters for new modules
 
-The Operator system provides the foundation for PETsARD's modular pipeline architecture, ensuring consistent and reliable execution across all data processing stages.
+The Adapter system provides the foundation for PETsARD's modular pipeline architecture, ensuring consistent and reliable execution across all data processing stages.

--- a/doc_site/content/docs/api/adapter.zh-tw.md
+++ b/doc_site/content/docs/api/adapter.zh-tw.md
@@ -1,5 +1,5 @@
 ---
-title: Operator
+title: Adapter
 type: docs
 weight: 61
 prev: docs/api/reporter
@@ -7,47 +7,47 @@ next: docs/api/config
 ---
 
 ```python
-petsard.operator
+petsard.adapter
 ```
 
-Operator 模組提供包裝類別，為所有 PETsARD 管線組件標準化執行介面。每個操作器封裝特定模組（Loader、Synthesizer 等），並提供一致的配置、執行和結果檢索方法。
+Adapter 模組提供包裝類別，為所有 PETsARD 管線組件標準化執行介面。每個適配器封裝特定模組（Loader、Synthesizer 等），並提供一致的配置、執行和結果檢索方法。
 
 ## 設計概覽
 
-Operator 系統遵循裝飾器模式，以標準化介面包裝核心模組進行管線執行。此設計確保所有管線組件的一致行為，同時保持模組特定功能的靈活性。
+Adapter 系統遵循裝飾器模式，以標準化介面包裝核心模組進行管線執行。此設計確保所有管線組件的一致行為，同時保持模組特定功能的靈活性。
 
 ### 核心原則
 
-1. **標準化**：所有操作器實作相同的基礎介面，確保管線執行的一致性
-2. **封裝**：每個操作器包裝對應的模組，處理配置和執行細節
-3. **錯誤處理**：跨所有操作器的全面錯誤記錄和例外處理
+1. **標準化**：所有適配器實作相同的基礎介面，確保管線執行的一致性
+2. **封裝**：每個適配器包裝對應的模組，處理配置和執行細節
+3. **錯誤處理**：跨所有適配器的全面錯誤記錄和例外處理
 4. **詮釋資料管理**：使用 Metadater 系統進行一致的詮釋資料處理
 
 ## 基礎類別
 
-### `BaseOperator`
+### `BaseAdapter`
 
 ```python
-BaseOperator(config)
+BaseAdapter(config)
 ```
 
-定義所有操作器標準介面的抽象基礎類別。
+定義所有適配器標準介面的抽象基礎類別。
 
 **參數**
-- `config` (dict)：操作器的配置參數
+- `config` (dict)：適配器的配置參數
 
 **方法**
-- `run(input)`：執行操作器的功能
+- `run(input)`：執行適配器的功能
 - `set_input(status)`：從管線狀態配置輸入資料
-- `get_result()`：檢索操作器的輸出資料
+- `get_result()`：檢索適配器的輸出資料
 - `get_metadata()`：檢索與輸出相關的詮釋資料
 
-## 操作器類別
+## 適配器類別
 
-### `LoaderOperator`
+### `LoaderAdapter`
 
 ```python
-LoaderOperator(config)
+LoaderAdapter(config)
 ```
 
 包裝 Loader 模組進行資料載入操作。
@@ -63,10 +63,10 @@ LoaderOperator(config)
 - `get_result()`：回傳載入的 DataFrame
 - `get_metadata()`：回傳載入資料的 SchemaMetadata
 
-### `SplitterOperator`
+### `SplitterAdapter`
 
 ```python
-SplitterOperator(config)
+SplitterAdapter(config)
 ```
 
 包裝 Splitter 模組進行資料分割操作。
@@ -81,10 +81,10 @@ SplitterOperator(config)
 - `get_result()`：回傳包含 'train' 和 'validation' DataFrame 的字典
 - `get_metadata()`：回傳包含分割資訊的更新 SchemaMetadata
 
-### `PreprocessorOperator`
+### `PreprocessorAdapter`
 
 ```python
-PreprocessorOperator(config)
+PreprocessorAdapter(config)
 ```
 
 包裝 Processor 模組進行資料前處理操作。
@@ -98,10 +98,10 @@ PreprocessorOperator(config)
 - `get_result()`：回傳前處理的 DataFrame
 - `get_metadata()`：回傳更新的 SchemaMetadata
 
-### `SynthesizerOperator`
+### `SynthesizerAdapter`
 
 ```python
-SynthesizerOperator(config)
+SynthesizerAdapter(config)
 ```
 
 包裝 Synthesizer 模組進行合成資料生成。
@@ -114,10 +114,10 @@ SynthesizerOperator(config)
 **主要方法**
 - `get_result()`：回傳合成的 DataFrame
 
-### `PostprocessorOperator`
+### `PostprocessorAdapter`
 
 ```python
-PostprocessorOperator(config)
+PostprocessorAdapter(config)
 ```
 
 包裝 Processor 模組進行資料後處理操作。
@@ -128,10 +128,10 @@ PostprocessorOperator(config)
 **主要方法**
 - `get_result()`：回傳後處理的 DataFrame
 
-### `ConstrainerOperator`
+### `ConstrainerAdapter`
 
 ```python
-ConstrainerOperator(config)
+ConstrainerAdapter(config)
 ```
 
 包裝 Constrainer 模組應用資料約束。
@@ -145,10 +145,10 @@ ConstrainerOperator(config)
 **主要方法**
 - `get_result()`：回傳約束後的 DataFrame
 
-### `EvaluatorOperator`
+### `EvaluatorAdapter`
 
 ```python
-EvaluatorOperator(config)
+EvaluatorAdapter(config)
 ```
 
 包裝 Evaluator 模組進行資料品質評估。
@@ -160,10 +160,10 @@ EvaluatorOperator(config)
 **主要方法**
 - `get_result()`：回傳按指標類型分類的評估結果字典
 
-### `DescriberOperator`
+### `DescriberAdapter`
 
 ```python
-DescriberOperator(config)
+DescriberAdapter(config)
 ```
 
 包裝 Describer 模組進行描述性資料分析。
@@ -175,10 +175,10 @@ DescriberOperator(config)
 **主要方法**
 - `get_result()`：回傳描述性分析結果字典
 
-### `ReporterOperator`
+### `ReporterAdapter`
 
 ```python
-ReporterOperator(config)
+ReporterAdapter(config)
 ```
 
 包裝 Reporter 模組進行結果匯出和報告。
@@ -194,24 +194,24 @@ ReporterOperator(config)
 
 ## 使用範例
 
-### 基本操作器使用
+### 基本適配器使用
 
 ```python
-from petsard.operator import LoaderOperator
+from petsard.adapter import LoaderAdapter
 
-# 建立和配置操作器
+# 建立和配置適配器
 config = {"filepath": "data.csv"}
-loader_op = LoaderOperator(config)
+loader_adapter = LoaderAdapter(config)
 
 # 設定輸入（通常由 Executor 完成）
-input_data = loader_op.set_input(status)
+input_data = loader_adapter.set_input(status)
 
 # 執行操作
-loader_op.run(input_data)
+loader_adapter.run(input_data)
 
 # 檢索結果
-data = loader_op.get_result()
-metadata = loader_op.get_metadata()
+data = loader_adapter.get_result()
+metadata = loader_adapter.get_metadata()
 ```
 
 ### 管線整合
@@ -220,7 +220,7 @@ metadata = loader_op.get_metadata()
 from petsard.config import Config
 from petsard.executor import Executor
 
-# 操作器通常透過 Config 和 Executor 使用
+# 適配器通常透過 Config 和 Executor 使用
 config_dict = {
     "Loader": {"load_data": {"filepath": "data.csv"}},
     "Synthesizer": {"synth": {"method": "sdv", "model": "GaussianCopula"}},
@@ -235,7 +235,7 @@ executor.run()
 ## 架構優勢
 
 ### 1. 一致介面
-- **標準化方法**：所有操作器實作相同的基礎介面
+- **標準化方法**：所有適配器實作相同的基礎介面
 - **可預測行為**：跨所有模組的一致執行模式
 
 ### 2. 錯誤處理
@@ -247,7 +247,7 @@ executor.run()
 - **資料流**：管線階段間的標準化資料傳遞
 
 ### 4. 模組化
-- **關注點分離**：每個操作器處理一個特定功能
-- **可擴展性**：容易為新模組添加新操作器
+- **關注點分離**：每個適配器處理一個特定功能
+- **可擴展性**：容易為新模組添加新適配器
 
-Operator 系統為 PETsARD 的模組化管線架構提供基礎，確保所有資料處理階段的一致和可靠執行。
+Adapter 系統為 PETsARD 的模組化管線架構提供基礎，確保所有資料處理階段的一致和可靠執行。

--- a/doc_site/content/docs/api/config.md
+++ b/doc_site/content/docs/api/config.md
@@ -2,7 +2,7 @@
 title: Config
 type: docs
 weight: 62
-prev: docs/api/operator
+prev: docs/api/adapter
 next: docs/api/status
 ---
 
@@ -10,16 +10,16 @@ next: docs/api/status
 Config(config)
 ```
 
-The Config class manages experiment configuration and creates operator execution flows for the PETsARD pipeline. It parses configuration dictionaries, validates settings, and generates queues of operators for sequential execution.
+The Config class manages experiment configuration and creates adapter execution flows for the PETsARD pipeline. It parses configuration dictionaries, validates settings, and generates queues of adapters for sequential execution.
 
 ## Design Overview
 
-The Config system transforms declarative configuration into executable pipeline flows. It handles module sequencing, experiment naming, and operator instantiation while providing validation and error checking.
+The Config system transforms declarative configuration into executable pipeline flows. It handles module sequencing, experiment naming, and adapter instantiation while providing validation and error checking.
 
 ### Key Principles
 
 1. **Declarative Configuration**: Define experiments through structured dictionaries
-2. **Automatic Flow Generation**: Convert configuration into executable operator sequences
+2. **Automatic Flow Generation**: Convert configuration into executable adapter sequences
 3. **Validation**: Comprehensive configuration validation and error reporting
 4. **Flexibility**: Support for complex experiment configurations and custom naming
 
@@ -81,9 +81,9 @@ config_dict = {
 
 ### Core Attributes
 
-- `config` (queue.Queue): Queue of instantiated operators ready for execution
-- `module_flow` (queue.Queue): Queue of module names corresponding to each operator
-- `expt_flow` (queue.Queue): Queue of experiment names corresponding to each operator
+- `config` (queue.Queue): Queue of instantiated adapters ready for execution
+- `module_flow` (queue.Queue): Queue of module names corresponding to each adapter
+- `expt_flow` (queue.Queue): Queue of experiment names corresponding to each adapter
 - `sequence` (list): List of module names in execution order
 - `yaml` (dict): The processed configuration dictionary
 
@@ -95,7 +95,7 @@ The Config class automatically processes the configuration during initialization
 
 1. **Validation**: Checks for invalid experiment naming patterns
 2. **Splitter Expansion**: Handles multi-sample splitting configurations
-3. **Operator Creation**: Instantiates operators for each experiment
+3. **Adapter Creation**: Instantiates adapters for each experiment
 4. **Flow Generation**: Creates execution queues using depth-first search
 
 ## Special Handling
@@ -148,7 +148,7 @@ config = Config(config_dict)
 
 # Access configuration attributes
 print(f"Module sequence: {config.sequence}")
-print(f"Number of operators: {config.config.qsize()}")
+print(f"Number of adapters: {config.config.qsize()}")
 ```
 
 ### Complex Multi-Module Configuration
@@ -212,12 +212,12 @@ The Config class performs several validation checks:
 
 - **Naming validation**: Ensures experiment names don't use reserved patterns
 - **Structure validation**: Verifies proper configuration hierarchy
-- **Parameter validation**: Delegates to individual operators for parameter checking
+- **Parameter validation**: Delegates to individual adapters for parameter checking
 
 ### Error Types
 
 - `ConfigError`: Raised for invalid configuration structures or naming violations
-- Module-specific errors: Propagated from individual operator initialization
+- Module-specific errors: Propagated from individual adapter initialization
 
 ## Architecture Benefits
 
@@ -239,6 +239,6 @@ The Config class performs several validation checks:
 ### 4. Integration
 - **Executor compatibility**: Seamless integration with execution system
 - **Status management**: Compatible with Status tracking system
-- **Operator abstraction**: Clean interface to underlying operators
+- **Adapter abstraction**: Clean interface to underlying adapters
 
 The Config system provides the foundation for PETsARD's flexible and robust experiment configuration, enabling complex data processing pipelines through simple declarative specifications.

--- a/doc_site/content/docs/api/config.zh-tw.md
+++ b/doc_site/content/docs/api/config.zh-tw.md
@@ -2,7 +2,7 @@
 title: Config
 type: docs
 weight: 62
-prev: docs/api/operator
+prev: docs/api/adapter
 next: docs/api/status
 ---
 

--- a/doc_site/content/docs/api/reporter.md
+++ b/doc_site/content/docs/api/reporter.md
@@ -3,7 +3,7 @@ title: Reporter
 type: docs
 weight: 60
 prev: docs/api/describer
-next: docs/api/operator
+next: docs/api/adapter
 ---
 
 

--- a/doc_site/content/docs/api/reporter.zh-tw.md
+++ b/doc_site/content/docs/api/reporter.zh-tw.md
@@ -3,7 +3,7 @@ title: Reporter
 type: docs
 weight: 60
 prev: docs/api/describer
-next: docs/api/operator
+next: docs/api/adapter
 ---
 
 

--- a/doc_site/content/docs/api/status.md
+++ b/doc_site/content/docs/api/status.md
@@ -74,16 +74,16 @@ Main Types: Status, StatusSummary
 #### `put()`
 
 ```python
-status.put(module, experiment_name, operator)
+status.put(module, experiment_name, adapter)
 ```
 
-Add module status and operator to the status dictionary with automatic snapshot creation.
+Add module status and adapter to the status dictionary with automatic snapshot creation.
 
 **Parameters**
 
 - `module` (str): Current module name
 - `experiment_name` (str): Current experiment name  
-- `operator` (BaseOperator): Current operator instance
+- `adapter` (BaseAdapter): Current adapter instance
 
 **Enhanced Behavior**
 - Creates execution snapshots automatically
@@ -293,7 +293,7 @@ config = Config(config_dict)
 status = Status(config)
 
 # Traditional usage (unchanged)
-# status.put(module, experiment, operator)  # Called by Executor
+# status.put(module, experiment, adapter)  # Called by Executor
 result = status.get_result("Loader")
 metadata = status.get_metadata("Loader")
 ```
@@ -397,7 +397,7 @@ The new Status is fully backward compatible. Existing code continues to work unc
 
 ```python
 # Existing code (no changes needed)
-status.put(module, experiment, operator)
+status.put(module, experiment, adapter)
 result = status.get_result(module)
 metadata = status.get_metadata(module)
 

--- a/doc_site/content/docs/api/status.zh-tw.md
+++ b/doc_site/content/docs/api/status.zh-tw.md
@@ -74,7 +74,7 @@ Status 採用以 Metadater 為中心的架構，提供全面的進度追蹤和�
 #### `put()`
 
 ```python
-status.put(module, experiment_name, operator)
+status.put(module, experiment_name, adapter)
 ```
 
 將模組狀態和操作器新增到狀態字典，並自動建立快照。
@@ -83,7 +83,7 @@ status.put(module, experiment_name, operator)
 
 - `module` (str)：當前模組名稱
 - `experiment_name` (str)：當前實驗名稱
-- `operator` (BaseOperator)：當前操作器實例
+- `adapter` (BaseAdapter)：當前適配器實例
 
 **增強行為**
 - 自動建立執行快照
@@ -293,7 +293,7 @@ config = Config(config_dict)
 status = Status(config)
 
 # 傳統使用方式（不變）
-# status.put(module, experiment, operator)  # 由 Executor 呼叫
+# status.put(module, experiment, adapter)  # 由 Executor 呼叫
 result = status.get_result("Loader")
 metadata = status.get_metadata("Loader")
 ```
@@ -397,7 +397,7 @@ else:
 
 ```python
 # 現有程式碼（無需變更）
-status.put(module, experiment, operator)
+status.put(module, experiment, adapter)
 result = status.get_result(module)
 metadata = status.get_metadata(module)
 

--- a/petsard/adapter.py
+++ b/petsard/adapter.py
@@ -16,7 +16,7 @@ from petsard.reporter import Reporter
 from petsard.synthesizer import Synthesizer
 
 
-class BaseOperator:
+class BaseAdapter:
     """
     The interface of the objects used by Executor.run()
     """
@@ -88,7 +88,7 @@ class BaseOperator:
             except Exception as e:
                 self._logger.error(f"Configuration error in {func.__name__}: {str(e)}")
                 self._logger.debug("Error details: ", exc_info=True)
-                raise ConfigError(f"Config error in {func.__name__}: {str(e)}")
+                raise ConfigError(f"Config error in {func.__name__}: {str(e)}") from e
 
         return wrapper
 
@@ -106,7 +106,7 @@ class BaseOperator:
                 )
                 raise NotImplementedError(
                     f"Method {func.__name__} must be implemented in {self.module_name}"
-                )
+                ) from None
 
         return wrapper
 
@@ -150,9 +150,9 @@ class BaseOperator:
         raise NotImplementedError
 
 
-class LoaderOperator(BaseOperator):
+class LoaderAdapter(BaseAdapter):
     """
-    LoaderOperator is responsible for loading data using the configured Loader instance as a decorator.
+    LoaderAdapter is responsible for loading data using the configured Loader instance as a decorator.
     """
 
     def __init__(self, config: dict):
@@ -190,7 +190,7 @@ class LoaderOperator(BaseOperator):
 
     def set_input(self, status) -> dict:
         """
-        Sets the input for the LoaderOperator.
+        Sets the input for the LoaderAdapter.
 
         Args:
             status (Status): The current status object.
@@ -216,9 +216,9 @@ class LoaderOperator(BaseOperator):
         return self.metadata
 
 
-class SplitterOperator(BaseOperator):
+class SplitterAdapter(BaseAdapter):
     """
-    SplitterOperator is responsible for splitting data
+    SplitterAdapter is responsible for splitting data
         using the configured Loader instance as a decorator.
     """
 
@@ -264,10 +264,10 @@ class SplitterOperator(BaseOperator):
         )
         self._logger.debug("Data splitting completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the SplitterOperator.
+        Sets the input for the SplitterAdapter.
 
         Args:
             status (Status): The current status object.
@@ -314,9 +314,9 @@ class SplitterOperator(BaseOperator):
         return deepcopy(self.train_indices)
 
 
-class PreprocessorOperator(BaseOperator):
+class PreprocessorAdapter(BaseAdapter):
     """
-    PreprocessorOperator is responsible for pre-processing data
+    PreprocessorAdapter is responsible for pre-processing data
         using the configured Processor instance as a decorator.
     """
 
@@ -377,10 +377,10 @@ class PreprocessorOperator(BaseOperator):
         self._logger.debug("Transforming data")
         self.data_preproc = self.processor.transform(data=input["data"])
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the PreprocessorOperator.
+        Sets the input for the PreprocessorAdapter.
 
         Args:
             status (Status): The current status object.
@@ -424,9 +424,9 @@ class PreprocessorOperator(BaseOperator):
         return metadata
 
 
-class SynthesizerOperator(BaseOperator):
+class SynthesizerAdapter(BaseAdapter):
     """
-    SynthesizerOperator is responsible for synthesizing data
+    SynthesizerAdapter is responsible for synthesizing data
         using the configured Synthesizer instance as a decorator.
     """
 
@@ -460,10 +460,10 @@ class SynthesizerOperator(BaseOperator):
         self.data_syn = self.synthesizer.fit_sample(data=input["data"])
         self._logger.debug("Train and sampling Synthesizing model completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the SynthesizerOperator.
+        Sets the input for the SynthesizerAdapter.
 
         Args:
             status (Status): The current status object.
@@ -502,9 +502,9 @@ class SynthesizerOperator(BaseOperator):
         return deepcopy(self.data_syn)
 
 
-class PostprocessorOperator(BaseOperator):
+class PostprocessorAdapter(BaseAdapter):
     """
-    PostprocessorOperator is responsible for post-processing data
+    PostprocessorAdapter is responsible for post-processing data
         using the configured Processor instance as a decorator.
     """
 
@@ -541,10 +541,10 @@ class PostprocessorOperator(BaseOperator):
         self.data_postproc = self.processor.inverse_transform(data=input["data"])
         self._logger.debug("Data postprocessing completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the PostprocessorOperator.
+        Sets the input for the PostprocessorAdapter.
 
         Args:
             status (Status): The current status object.
@@ -566,15 +566,15 @@ class PostprocessorOperator(BaseOperator):
         return result
 
 
-class ConstrainerOperator(BaseOperator):
+class ConstrainerAdapter(BaseAdapter):
     """
-    ConstrainerOperator is responsible for applying constraints to data
+    ConstrainerAdapter is responsible for applying constraints to data
     using the configured Constrainer instance as a decorator.
     """
 
     def __init__(self, config: dict):
         """
-        Initialize ConstrainerOperator with given configuration.
+        Initialize ConstrainerAdapter with given configuration.
 
         Args:
             config (dict): Configuration parameters for the Constrainer.
@@ -638,10 +638,10 @@ class ConstrainerOperator(BaseOperator):
 
         self._logger.debug("Data constraining completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Set the input for the ConstrainerOperator.
+        Set the input for the ConstrainerAdapter.
 
         Args:
             status (Status): The current status object.
@@ -698,9 +698,9 @@ class ConstrainerOperator(BaseOperator):
         return config
 
 
-class EvaluatorOperator(BaseOperator):
+class EvaluatorAdapter(BaseAdapter):
     """
-    EvaluatorOperator is responsible for evaluating data
+    EvaluatorAdapter is responsible for evaluating data
         using the configured Evaluator instance as a decorator.
     """
 
@@ -732,10 +732,10 @@ class EvaluatorOperator(BaseOperator):
         self.evaluations = self.evaluator.eval(**input)
         self._logger.debug("Data evaluating completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the EvaluatorOperator.
+        Sets the input for the EvaluatorAdapter.
 
         Args:
             status (Status): The current status object.
@@ -768,9 +768,9 @@ class EvaluatorOperator(BaseOperator):
         return deepcopy(self.evaluations)
 
 
-class DescriberOperator(BaseOperator):
+class DescriberAdapter(BaseAdapter):
     """
-    DescriberOperator is responsible for describing data
+    DescriberAdapter is responsible for describing data
         using the configured Describer instance as a decorator.
     """
 
@@ -810,10 +810,10 @@ class DescriberOperator(BaseOperator):
         self.description = self.describer.eval(**input)
         self._logger.debug("Data describing completed")
 
-    @BaseOperator.log_and_raise_config_error
+    @BaseAdapter.log_and_raise_config_error
     def set_input(self, status) -> dict:
         """
-        Sets the input for the DescriberOperator.
+        Sets the input for the DescriberAdapter.
 
         Args:
             status (Status): The current status object.
@@ -844,7 +844,7 @@ class DescriberOperator(BaseOperator):
         return deepcopy(self.description)
 
 
-class ReporterOperator(BaseOperator):
+class ReporterAdapter(BaseAdapter):
     """
     Operator class for generating reports using the Reporter class.
 

--- a/petsard/config.py
+++ b/petsard/config.py
@@ -1,21 +1,20 @@
 import queue
 import re
 from copy import deepcopy
-from typing import Tuple
 
-from petsard.exceptions import ConfigError
-from petsard.operator import (
-    BaseOperator,  # noqa: F401 - Dynamic Imports
-    ConstrainerOperator,
-    DescriberOperator,
-    EvaluatorOperator,
-    LoaderOperator,
-    PostprocessorOperator,
-    PreprocessorOperator,
-    ReporterOperator,
-    SplitterOperator,
-    SynthesizerOperator,
+from petsard.adapter import (  # noqa: F401 - Dynamic Imports
+    BaseAdapter,
+    ConstrainerAdapter,
+    DescriberAdapter,
+    EvaluatorAdapter,
+    LoaderAdapter,
+    PostprocessorAdapter,
+    PreprocessorAdapter,
+    ReporterAdapter,
+    SplitterAdapter,
+    SynthesizerAdapter,
 )
+from petsard.exceptions import ConfigError
 
 
 class Config:
@@ -50,7 +49,7 @@ class Config:
 
         # Config check
         pattern = re.compile(r"_(\[[^\]]*\])$")
-        for module, expt_config in self.yaml.items():
+        for _module, expt_config in self.yaml.items():
             for expt_name in expt_config:
                 # any expt_name should not be postfix with "_[xxx]"
                 if pattern.search(expt_name):
@@ -64,7 +63,7 @@ class Config:
 
         self.config, self.module_flow, self.expt_flow = self._set_flow()
 
-    def _set_flow(self) -> Tuple[queue.Queue, queue.Queue, queue.Queue]:
+    def _set_flow(self) -> tuple[queue.Queue, queue.Queue, queue.Queue]:
         """
         Populate queues with module operators.
 
@@ -92,8 +91,8 @@ class Config:
             remaining_modules = modules[1:]
 
             if module in self.yaml:
-                for expt_name, expt_config in self.yaml[module].items():
-                    flow.put(eval(f"{module}Operator(expt_config)"))
+                for expt_name, expt_config in self.yaml[module].items():  # noqa: B007
+                    flow.put(eval(f"{module}Adapter(expt_config)"))
                     module_flow.put(module)
                     expt_flow.put(expt_name)
                     _set_flow_dfs(remaining_modules)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,16 @@
 import queue
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import Mock
 
 import pandas as pd
 import pytest
 
+from petsard.adapter import BaseAdapter
 from petsard.config import Config
 from petsard.config_base import BaseConfig, ConfigGetParamActionMap
 from petsard.exceptions import ConfigError, UnexecutedError
 from petsard.metadater import SchemaMetadata
-from petsard.operator import BaseOperator
 from petsard.status import Status
 
 
@@ -24,8 +24,8 @@ class TestConfigClass(BaseConfig):
 
     a: int
     b: int
-    c: Dict[Any, Any] = field(default_factory=dict)
-    d: Dict[Any, Any] = field(default_factory=dict)
+    c: dict[Any, Any] = field(default_factory=dict)
+    d: dict[Any, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         super().__post_init__()
@@ -125,7 +125,7 @@ class TestStatus:
     def test_put_and_get_result(self):
         """測試狀態儲存和結果取得"""
         # 建立模擬操作器
-        mock_operator = Mock(spec=BaseOperator)
+        mock_operator = Mock(spec=BaseAdapter)
         mock_operator.get_result.return_value = pd.DataFrame({"A": [1, 2, 3]})
 
         # 建立模擬 SchemaMetadata
@@ -170,8 +170,8 @@ class TestStatus:
     def test_get_full_expt(self):
         """測試取得完整實驗配置"""
         # 建立模擬操作器
-        mock_operator1 = Mock(spec=BaseOperator)
-        mock_operator2 = Mock(spec=BaseOperator)
+        mock_operator1 = Mock(spec=BaseAdapter)
+        mock_operator2 = Mock(spec=BaseAdapter)
 
         # 儲存狀態
         self.status.put("Loader", "load_data", mock_operator1)
@@ -190,7 +190,7 @@ class TestStatus:
     def test_report_management(self):
         """測試報告管理"""
         # 建立模擬報告操作器
-        mock_operator = Mock(spec=BaseOperator)
+        mock_operator = Mock(spec=BaseAdapter)
         mock_report = {"test_report": pd.DataFrame({"metric": [0.8, 0.9]})}
         mock_operator.get_result.return_value = mock_report
 
@@ -210,9 +210,9 @@ class TestStatus:
     def test_status_renewal(self):
         """測試狀態更新機制"""
         # 建立模擬操作器
-        mock_operator1 = Mock(spec=BaseOperator)
-        mock_operator2 = Mock(spec=BaseOperator)
-        mock_operator3 = Mock(spec=BaseOperator)
+        mock_operator1 = Mock(spec=BaseAdapter)
+        mock_operator2 = Mock(spec=BaseAdapter)
+        mock_operator3 = Mock(spec=BaseAdapter)
 
         # 第一輪執行
         self.status.put("Loader", "load_data", mock_operator1)
@@ -265,9 +265,9 @@ class TestConfigIntegration:
         operator = config.config.get()
 
         # 驗證操作器類型
-        from petsard.operator import LoaderOperator
+        from petsard.adapter import LoaderAdapter
 
-        assert isinstance(operator, LoaderOperator)
+        assert isinstance(operator, LoaderAdapter)
 
 
 class TestBaseConfig:


### PR DESCRIPTION
close #858 

- refactor
  - (core): rename operator module to adapter pattern - ab0029e487325c1766acc7c9355c5092ba68e559

- docs:
  - update API documentation for adapter pattern - c38beb9a1a6f19b23feef3e7ed001197d25f6d8f
  - update development documentation for adapter pattern - a55e4d28bc5c548c0b7a16d3a14adc5c2e1bc652
- test: update test files for adapter pattern refactoring - 99710c091a135b89f359f46c24cae31913dec068