### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @matheme-justyn


### PR DESCRIPTION
Add .github/CODEOWNERS assigning repo-wide ownership to @matheme-justyn.