### PR TITLE
fix(deps): bump soupsieve to 2.8.4 to fix CVE-2026-49476/49477

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3217,11 +3217,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 問題

`Scan vulnerabilities`（trivy）掃描 `uv.lock` 時，`soupsieve` 2.8 觸發兩個 HIGH 等級漏洞，使 CI 失敗：

| CVE | 說明 | 修復版本 |
|-----|------|----------|
| CVE-2026-49476 | 超大逗號分隔 selector list 導致記憶體耗盡 | 2.8.4 |
| CVE-2026-49477 | selector parser 的 ReDoS | 2.8.4 |

`soupsieve` 是 `beautifulsoup4` 的間接依賴，此漏洞為 dev 上既有問題，會讓所有 PR 的漏洞掃描失敗（例如 #1022）。

## 變更

將 `uv.lock` 中的 `soupsieve` 從 2.8 升到 2.8.4（已通過 `uv lock --check`，僅動到該套件）。

合併後可對 #1022 留言 `@dependabot rebase` 讓其重跑掃描。
